### PR TITLE
demo.css: fix demo options not shown on Chrome

### DIFF
--- a/src/styles/demo.css
+++ b/src/styles/demo.css
@@ -270,6 +270,11 @@ body .dg .dg.main.a {
   -webkit-appearance: none;
 }
 
+.matter-select option {
+  background: white;
+  color: black;
+}
+
 .prevent-zoom-ios .matter-select {
   font-size: 16px;
 }


### PR DESCRIPTION
Chrome doesn't allow changing the background color of the <option>
but it allows changing the text color.
As a result, the text was white on a white background.

Since Firefox allows background styling, the <option>
background is standardized to white so it works the
same in Firefox.

Before on Chrome:

![image](https://user-images.githubusercontent.com/1469823/34655875-7905c48c-f411-11e7-87ad-d3ab875579cc.png)

Before on Firefox:

![image](https://user-images.githubusercontent.com/1469823/34655873-6fba906a-f411-11e7-832c-835ca95c0624.png)

After on Chrome and Firefox:

![image](https://user-images.githubusercontent.com/1469823/34655883-8ad461d2-f411-11e7-8994-f8530ea5a871.png)

PS: the newline at the end of the file was created by the Github editor, feel free to remove it